### PR TITLE
Refactor for isRegistered and exactly-once delivery

### DIFF
--- a/flow-typed/npm/jest_v20.x.x.js
+++ b/flow-typed/npm/jest_v20.x.x.js
@@ -166,7 +166,7 @@ type JestExpectType = {
    */
   toBeInstanceOf(cls: Class<*>): void,
   /**
-   * .toBeNull() is the same as .toBe(null) but the error textMessages are a bit
+   * .toBeNull() is the same as .toBe(null) but the error messages are a bit
    * nicer.
    */
   toBeNull(): void,
@@ -389,7 +389,7 @@ declare function afterEach(fn: Function): void;
 declare function beforeEach(fn: Function): void;
 /** Runs this function after all tests have finished inside this context */
 declare function afterAll(fn: Function): void;
-/** Runs this function before any tests have connected inside this context */
+/** Runs this function before any tests have started inside this context */
 declare function beforeAll(fn: Function): void;
 /** A context for grouping tests together */
 declare function describe(name: string, fn: Function): void;

--- a/flow-typed/npm/jest_v20.x.x.js
+++ b/flow-typed/npm/jest_v20.x.x.js
@@ -166,7 +166,7 @@ type JestExpectType = {
    */
   toBeInstanceOf(cls: Class<*>): void,
   /**
-   * .toBeNull() is the same as .toBe(null) but the error messages are a bit
+   * .toBeNull() is the same as .toBe(null) but the error textMessages are a bit
    * nicer.
    */
   toBeNull(): void,
@@ -389,7 +389,7 @@ declare function afterEach(fn: Function): void;
 declare function beforeEach(fn: Function): void;
 /** Runs this function after all tests have finished inside this context */
 declare function afterAll(fn: Function): void;
-/** Runs this function before any tests have started inside this context */
+/** Runs this function before any tests have connected inside this context */
 declare function beforeAll(fn: Function): void;
 /** A context for grouping tests together */
 declare function describe(name: string, fn: Function): void;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "quiq-chat",
-  "version": "1.3.0",
+  "version": "1.3.1",
   "description": "Library to help with network requests to create a webchat client for Quiq Messaging",
   "main": "build/quiq-chat.js",
   "repository": "https://github.com/Quiq/quiq-chat",

--- a/src/QuiqChatClient.js
+++ b/src/QuiqChatClient.js
@@ -256,9 +256,10 @@ class QuiqChatClient {
     const newMessages = differenceBy(messages, this.textMessages, 'id');
     const newEvents = differenceBy(events, this.events, 'id');
 
+    const sortedNewMessages = sortByTimestamp(newMessages);
+
     if (newMessages.length && this.callbacks.onNewMessages && sendNewMessageCallback) {
-      // $FlowIssue - flow doesn't believe thie below callback is defined at this point
-      this.callbacks.onNewMessages(sortByTimestamp(newMessages));
+      this.callbacks.onNewMessages(sortedNewMessages);
     }
 
     const sortedMessages = sortByTimestamp(this.textMessages.concat(newMessages));

--- a/src/QuiqChatClient.js
+++ b/src/QuiqChatClient.js
@@ -11,10 +11,7 @@ import {sortByTimestamp} from './utils';
 const getConversation = async (): Promise<{events: Array<Event>, messages: Array<TextMessage>}> => {
   const conversation = await API.fetchConversation();
   const partitionedConversation = partition(conversation.messages, {type: MessageTypes.TEXT});
-  // NOTE: For backwards compatibility, we must filter out 'Quiq Welcome Form Customer Submission' textMessages
-  const messages = partitionedConversation[0].filter(
-    m => !m.text.trim().includes('Quiq Welcome Form Customer Submission'),
-  );
+  const messages = partitionedConversation[0];
   const events = partitionedConversation[1];
   return {messages, events};
 };
@@ -260,7 +257,8 @@ class QuiqChatClient {
     const newEvents = differenceBy(events, this.events, 'id');
 
     if (newMessages.length && this.callbacks.onNewMessages && sendNewMessageCallback) {
-      this.callbacks.onNewMessages(newMessages);
+      // $FlowIssue - flow doesn't believe thie below callback is defined at this point
+      this.callbacks.onNewMessages(sortByTimestamp(newMessages));
     }
 
     const sortedMessages = sortByTimestamp(this.textMessages.concat(newMessages));

--- a/src/__tests__/QuiqChatClient.test.js
+++ b/src/__tests__/QuiqChatClient.test.js
@@ -150,7 +150,13 @@ describe('QuiqChatClient', () => {
   });
 
   describe('getting new messages', () => {
-    const newMessage = {type: 'Text', id: 'msg3', timestamp: 3, text: 'blorp'};
+    const newMessage = {
+      authorType: 'Customer',
+      type: 'Text',
+      id: 'msg3',
+      timestamp: 3,
+      text: 'blorp',
+    };
 
     beforeEach(() => {
       if (!client) {
@@ -165,7 +171,25 @@ describe('QuiqChatClient', () => {
     });
 
     it('calls onNewMessages', () => {
-      expect(onNewMessages).toBeCalledWith([...initialConvo.messages, newMessage]);
+      expect(onNewMessages).toBeCalledWith([newMessage]);
+    });
+  });
+
+  describe('getting new Register event', () => {
+    const newEvent = {type: 'Register', id: 'reg1', timestamp: 3};
+
+    it('updates userIsRegistered', () => {
+      if (!client) {
+        throw new Error('Client should be defined');
+      }
+
+      expect(client.isRegistered()).toBe(false);
+      client._handleWebsocketMessage({
+        messageType: 'ChatMessage',
+        tenantId: 'test',
+        data: newEvent,
+      });
+      expect(client.isRegistered()).toBe(true);
     });
   });
 

--- a/src/appConstants.js
+++ b/src/appConstants.js
@@ -6,6 +6,11 @@ export const MessageTypes = {
   // eslint-disable-line import/prefer-default-export
   TEXT: 'Text',
   CHAT_MESSAGE: 'ChatMessage',
+  JOIN: 'Join',
+  LEAVE: 'Leave',
+  REGISTER: 'Register',
+  BURN_IT_DOWN: 'BurnItDown',
+  AGENT_TYPING: 'AgentTyping',
 };
 
 export const SupportedWebchatUrls = [

--- a/src/types.js
+++ b/src/types.js
@@ -6,21 +6,38 @@ export type QuiqChatSettings = {
   BURNED?: boolean,
 };
 
-export type EventType = 'Text' | 'Join' | 'Leave';
+export type EventType = 'Join' | 'Leave' | 'Register';
 export type AuthorType = 'Customer' | 'Agent';
-export type MessageType = 'Text' | 'ChatMessage' | 'BurnItDown';
+export type TextMessageType = 'Text';
+export type WebsocketMessageType = 'ChatMessage';
+export type UserEventTypes = 'Join' | 'Leave';
 
-export type Message = {
+export type TextMessage = {
   authorType: AuthorType,
   text: string,
+  id: string,
+  timestamp: number,
+  type: TextMessageType,
+};
+
+export type Event = {
   id: string,
   timestamp: number,
   type: EventType,
 };
 
+export type AgentTypingMessage = {
+  type: 'AgentTyping',
+  typing: boolean,
+};
+
+export type BurnItDownMessage = {
+  type: 'BurnItDown',
+};
+
 export type Conversation = {
   id: string,
-  messages: Array<Message>,
+  messages: Array<TextMessage | Event>,
 };
 export type AtmosphereTransportType =
   | 'websocket'
@@ -97,18 +114,18 @@ export type AtmosphereConnection = {
 };
 
 export type AtmosphereMessage = {
-  data: Object,
-  messageType: MessageType,
   tenantId: string,
+  messageType: WebsocketMessageType,
+  data: Event | TextMessage | AgentTypingMessage | BurnItDownMessage,
 };
 
 export type WebsocketCallbacks = {
-  onConnectionLoss?: () => void,
-  onConnectionEstablish?: () => void,
-  onMessage?: (message: AtmosphereMessage) => void,
-  onTransportFailure?: (errorMsg: string, req: AtmosphereRequest) => void,
-  onClose?: () => void,
-  onBurn?: (burnData: BurnItDownResponse) => void,
+  onConnectionLoss?: () => any,
+  onConnectionEstablish?: () => any,
+  onMessage?: (message: AtmosphereMessage) => any,
+  onTransportFailure?: (errorMsg: string, req: AtmosphereRequest) => any,
+  onClose?: () => any,
+  onBurn?: (burnData: BurnItDownResponse) => any,
 };
 
 export type BrowserNames =
@@ -258,5 +275,3 @@ export type CookieDef = {
   expiration?: number,
   path?: string,
 };
-
-export type UserEventTypes = 'Join' | 'Leave';

--- a/src/utils.js
+++ b/src/utils.js
@@ -50,3 +50,7 @@ export const burnItDown = (message?: BurnItDownResponse) => {
     unsubscribe();
   }, timeToBurnItDown);
 };
+
+export const sortByTimestamp = (messages: Array<{timestamp: number}>): Array<Object> => {
+  return messages.sort((a, b) => a.timestamp - b.timestamp);
+};

--- a/src/utils.js
+++ b/src/utils.js
@@ -51,6 +51,5 @@ export const burnItDown = (message?: BurnItDownResponse) => {
   }, timeToBurnItDown);
 };
 
-export const sortByTimestamp = (messages: Array<{timestamp: number}>): Array<Object> => {
-  return messages.sort((a, b) => a.timestamp - b.timestamp);
-};
+export const sortByTimestamp = (arr: Array<Object>): Array<Object> =>
+  arr.slice().sort((a, b) => a.timestamp - b.timestamp);

--- a/yarn.lock
+++ b/yarn.lock
@@ -2494,7 +2494,7 @@ jest@^20.0.4:
   dependencies:
     jest-cli "^20.0.4"
 
-js-cookie@^2.1.4:
+js-cookie@2.1.4:
   version "2.1.4"
   resolved "https://registry.yarnpkg.com/js-cookie/-/js-cookie-2.1.4.tgz#da4ec503866f149d164cf25f579ef31015025d8d"
 
@@ -2801,7 +2801,7 @@ lodash.restparam@^3.0.0:
   version "3.6.1"
   resolved "https://registry.yarnpkg.com/lodash.restparam/-/lodash.restparam-3.6.1.tgz#936a4e309ef330a7645ed4145986c85ae5b20805"
 
-lodash@^4.0.0, lodash@^4.13.1, lodash@^4.14.0, lodash@^4.15.0, lodash@^4.17.4, lodash@^4.2.0, lodash@^4.3.0:
+lodash@4.17.4, lodash@^4.0.0, lodash@^4.13.1, lodash@^4.14.0, lodash@^4.15.0, lodash@^4.2.0, lodash@^4.3.0:
   version "4.17.4"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.4.tgz#78203a4d1c328ae1d86dca6460e369b57f4055ae"
 


### PR DESCRIPTION
- Store events in `QuiqChatClient`, so we can search for `Registration`, `Join` and `Leave` events.
- Attempt to provide more meaningful typing around `WebsocketMessages` vs. `TextMessages` vs.` Events`
- Move all logic related to processing new events and messages to one method.- 
- Ensure that order of arrival and multiple delivery cases are handled: always invoke the `onNewMessages` callback exactly once per message and keep the `textMessages` array ordered.
- Add an `isRegistered()` method to be used for determining whether to display the `WelcomeForm`
- Keep track of user registration status to avoid continually searching the `events` array.
- If the websocket is not connected, don't return cached data--go fetch it!