### PR TITLE
Don't try to determine if user has active chat

### DIFF
--- a/README.md
+++ b/README.md
@@ -178,10 +178,10 @@ Submits a map of custom `(key, value)` pairs to be included in the data for the 
 Method accepts a single parameter, a JavaScript object with values of type `String`.
 `key` is limited to 80 characters and must be unique; `value` is limited to 1000 characters.
 
-#### hasActiveChat() => boolean
-Returns whether the end-user has performed a meaningful action that triggers a conversation, such as
+#### hasTakenMeaningfulAction() => boolean
+Returns whether the end-user has performed a meaningful action, such as
 submitting the Welcome Form, or sending a message to the agent.  State persists through
-page flips using `quiq-chat-launcher-visible` cookie.
+page flips using `quiq-user-taken-meaningful-action` cookie.
 
 #### isChatVisible() => boolean
 Returns the last state of chat's visibility.  Only includes actions that call the joinChat and leaveChat events.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "quiq-chat",
-  "version": "1.6.1",
+  "version": "1.7.1",
   "description": "Library to help with network requests to create a webchat client for Quiq Messaging",
   "main": "build/quiq-chat.js",
   "repository": "https://github.com/Quiq/quiq-chat",

--- a/src/QuiqChatClient.js
+++ b/src/QuiqChatClient.js
@@ -163,7 +163,7 @@ class QuiqChatClient {
 
   sendMessage = (text: string) => {
     cookies.setQuiqChatContainerVisibleCookie(true);
-    cookies.setQuiqLauncherVisibleCookie(true);
+    cookies.setQuiqUserTakenMeaningfulActionCookie(true);
     return API.addMessage(text);
   };
 
@@ -173,7 +173,7 @@ class QuiqChatClient {
 
   sendRegistration = (fields: {[string]: string}) => {
     cookies.setQuiqChatContainerVisibleCookie(true);
-    cookies.setQuiqLauncherVisibleCookie(true);
+    cookies.setQuiqUserTakenMeaningfulActionCookie(true);
     return API.sendRegistration(fields);
   };
 
@@ -181,19 +181,8 @@ class QuiqChatClient {
     return API.checkForAgents();
   };
 
-  isChatVisible = (): boolean => {
-    return cookies.getQuiqChatContainerVisibleCookie();
-  };
-
-  hasActiveChat = async () => {
-    if (!cookies.getQuiqLauncherVisibleCookie()) return false;
-
-    if (this.textMessages.length > 0) return true;
-
-    await this.getMessages();
-
-    return this.textMessages.length > 0;
-  };
+  isChatVisible = (): boolean => cookies.getQuiqChatContainerVisibleCookie();
+  hasTakenMeaningfulAction = (): boolean => cookies.getQuiqUserTakenMeaningfulActionCookie();
 
   getLastUserEvent = async (cache: boolean = true): Promise<UserEventTypes | null> => {
     if (!cache || !this.connected) {

--- a/src/__tests__/QuiqChatClient.test.js
+++ b/src/__tests__/QuiqChatClient.test.js
@@ -47,7 +47,7 @@ describe('QuiqChatClient', () => {
     API.fetchConversation.mockReturnValue(Promise.resolve(initialConvo));
     API.fetchWebsocketInfo.mockReturnValue({url: 'https://websocket.test'});
     mockCookies.getQuiqChatContainerVisibleCookie.mockReturnValue(true);
-    mockCookies.getQuiqLauncherVisibleCookie.mockReturnValue(true);
+    mockCookies.getQuiqUserTakenMeaningfulActionCookie.mockReturnValue(true);
 
     client = new QuiqChatClient(host, contactPoint)
       .onNewMessages(onNewMessages)
@@ -257,49 +257,20 @@ describe('QuiqChatClient', () => {
       });
     });
 
-    describe('hasActiveChat', () => {
+    describe('hasTakenMeaningfulAction', () => {
       beforeEach(() => {
         if (!client) {
           throw new Error('Client should be defined');
         }
       });
 
-      describe('when launcher is not visible', () => {
-        it('returns false', async () => {
-          if (!client) {
-            throw new Error('Client undefined');
-          }
+      it('returns the value of the quiq-user-taken-meaningful-action cookie value', () => {
+        if (!client) {
+          throw new Error('Client undefined');
+        }
 
-          mockCookies.getQuiqLauncherVisibleCookie.mockReturnValue(false);
-          const res = await client.hasActiveChat();
-          expect(res).toBe(false);
-        });
-      });
-
-      describe('when there are no messages', () => {
-        it('returns false', async () => {
-          if (!client) {
-            throw new Error('Client undefined');
-          }
-
-          mockCookies.getQuiqLauncherVisibleCookie.mockReturnValue(false);
-          API.fetchConversation.mockReturnValue([]);
-          const res = await client.hasActiveChat();
-          expect(res).toBe(false);
-        });
-      });
-
-      describe('when there are messages', () => {
-        it('returns true', async () => {
-          if (!client) {
-            throw new Error('Client undefined');
-          }
-
-          mockCookies.getQuiqLauncherVisibleCookie.mockReturnValue(true);
-          API.fetchConversation.mockReturnValue(initialConvo);
-          const res = await client.hasActiveChat();
-          expect(res).toBe(true);
-        });
+        mockCookies.getQuiqUserTakenMeaningfulActionCookie.mockReturnValueOnce(false);
+        expect(client.hasTakenMeaningfulAction()).toBe(false);
       });
     });
 
@@ -330,7 +301,7 @@ describe('QuiqChatClient', () => {
         client.sendMessage('text');
         expect(API.addMessage).toBeCalledWith('text');
         expect(mockCookies.setQuiqChatContainerVisibleCookie).toBeCalledWith(true);
-        expect(mockCookies.setQuiqLauncherVisibleCookie).toBeCalledWith(true);
+        expect(mockCookies.setQuiqUserTakenMeaningfulActionCookie).toBeCalledWith(true);
       });
     });
 
@@ -355,7 +326,7 @@ describe('QuiqChatClient', () => {
         client.sendRegistration(data);
         expect(API.sendRegistration).toBeCalledWith(data);
         expect(mockCookies.setQuiqChatContainerVisibleCookie).toBeCalledWith(true);
-        expect(mockCookies.setQuiqLauncherVisibleCookie).toBeCalledWith(true);
+        expect(mockCookies.setQuiqUserTakenMeaningfulActionCookie).toBeCalledWith(true);
       });
     });
   });

--- a/src/cookies.js
+++ b/src/cookies.js
@@ -4,10 +4,11 @@ import {set, get} from 'js-cookie';
 export const setQuiqChatContainerVisibleCookie = (visible: boolean) => {
   set('quiq-chat-container-visible', visible, {expires: 1});
 };
-export const setQuiqLauncherVisibleCookie = (visible: boolean) => {
-  set('quiq-chat-launcher-visible', visible, {expires: 1});
+export const setQuiqUserTakenMeaningfulActionCookie = (visible: boolean) => {
+  set('quiq-user-taken-meaningful-action', visible, {expires: 1});
 };
 
 export const getQuiqChatContainerVisibleCookie = () =>
   get('quiq-chat-container-visible') === 'true';
-export const getQuiqLauncherVisibleCookie = () => get('quiq-chat-launcher-visible') === 'true';
+export const getQuiqUserTakenMeaningfulActionCookie = () =>
+  get('quiq-user-taken-meaningful-action') === 'true';

--- a/src/types.js
+++ b/src/types.js
@@ -70,7 +70,8 @@ export type QuiqChatClientType = {
   updateMessagePreview: (text: string, typing: boolean) => void,
   sendRegistration: (fields: {[string]: string}) => void,
   checkForAgents: () => Promise<{available: boolean}>,
-  hasActiveChat: () => boolean,
+  isChatVisible: () => boolean,
+  hasTakenMeaningfulAction: () => boolean,
 };
 
 export type Conversation = {


### PR DESCRIPTION
Removed `hasActiveChat` since its main purpose was to be used before the client started a session.  hasActiveChat fetches the transcript to help determine if there is an active chat, so this call would fail since client hasn't yet begun a session.

Instead I decided to key only off of the `quiq-user-taken-meaningful-action` cookie, which gets set when the user submits welcome form or sends a message.

This info is enough for the client to then start a session and look at the transcript after the session is started to determine action.