### PR TITLE
WIP: Session changeover

### DIFF
--- a/src/__tests__/QuiqChatClient.test.js
+++ b/src/__tests__/QuiqChatClient.test.js
@@ -30,11 +30,14 @@ const initialConvo = {
   ],
 };
 
+const testTrackingId = 'dsafdsafaweufh';
+
 describe('QuiqChatClient', () => {
   const onNewMessages = jest.fn();
   const onAgentTyping = jest.fn();
   const onError = jest.fn();
   const onErrorResolved = jest.fn();
+  const onNewSession = jest.fn();
   const onConnectionStatusChange = jest.fn();
   const onBurn = jest.fn();
   const onRegistration = jest.fn();
@@ -57,6 +60,7 @@ describe('QuiqChatClient', () => {
       .onErrorResolved(onErrorResolved)
       .onConnectionStatusChange(onConnectionStatusChange)
       .onRegistration(onRegistration)
+      .onNewSession(onNewSession)
       .onBurn(onBurn);
 
     client.start();
@@ -168,6 +172,84 @@ describe('QuiqChatClient', () => {
 
     it('calls onNewMessages', () => {
       expect(onNewMessages).lastCalledWith(initialConvo.messages.concat(newMessage));
+    });
+  });
+
+  describe('handling new session', () => {
+    describe('when no trackingId is defined, i.e., this is first session', () => {
+      it('updates cached trackingId', () => {
+        if (!client) {
+          throw new Error('Client should be defined');
+        }
+
+        client._handleNewSession(testTrackingId);
+        expect(client.trackingId).toBe(testTrackingId);
+      });
+
+      it('does NOT fire new session callback', () => {
+        if (!client) {
+          throw new Error('Client should be defined');
+        }
+
+        client._handleNewSession(testTrackingId);
+        expect(client.callbacks.onNewSession).not.toHaveBeenCalled();
+      });
+    });
+
+    describe('when trackingId has not changed, i.e. session was refreshed', () => {
+      beforeEach(() => {
+        if (!client) {
+          throw new Error('Client should be defined');
+        }
+
+        client.trackingId = testTrackingId;
+      });
+
+      it('updates cached trackingId', () => {
+        if (!client) {
+          throw new Error('Client should be defined');
+        }
+
+        client._handleNewSession(testTrackingId);
+        expect(client.trackingId).toBe(testTrackingId);
+      });
+
+      it('does NOT fire new session callback', () => {
+        if (!client) {
+          throw new Error('Client should be defined');
+        }
+
+        client._handleNewSession(testTrackingId);
+        expect(client.callbacks.onNewSession).not.toHaveBeenCalled();
+      });
+    });
+
+    describe('when trackingId has changed, i.e. new conversation', () => {
+      beforeEach(() => {
+        if (!client) {
+          throw new Error('Client should be defined');
+        }
+
+        client.trackingId = 'oldId';
+      });
+
+      it('updates cached trackingId', async () => {
+        if (!client) {
+          throw new Error('Client should be defined');
+        }
+
+        await client._handleNewSession(testTrackingId);
+        expect(client.trackingId).toBe(testTrackingId);
+      });
+
+      it('does fire new session callback', () => {
+        if (!client) {
+          throw new Error('Client should be defined');
+        }
+
+        client._handleNewSession(testTrackingId);
+        expect(client.callbacks.onNewSession).toHaveBeenCalled();
+      });
     });
   });
 

--- a/src/apiCalls.js
+++ b/src/apiCalls.js
@@ -4,9 +4,9 @@ import {getUrlForContactPoint, getPublicApiUrl, getContactPoint, getSessionApiUr
 import quiqFetch from './quiqFetch';
 import type {Conversation} from 'types';
 
-let _onNewSession: () => void;
+let _onNewSession: (newTrackingId: string) => any;
 
-export const registerNewSessionCallback = (callback: () => void) => {
+export const registerNewSessionCallback = (callback: (newTrackingId: string) => any) => {
   _onNewSession = callback;
 };
 
@@ -69,12 +69,18 @@ export const checkForAgents = (): Promise<{available: boolean}> =>
  * @param host - Host against which to call /generate
  * @param sessionChange - Indicates whether this is being called to replace old session. Results in newSession callback being fired.
  */
-export const login = (host?: string, sessionChange?: boolean = false) =>
-  quiqFetch(`${getSessionApiUrl(host)}/generate`, {
-    credentials: 'include',
-    method: 'POST',
-  }).then(() => {
-    if (sessionChange && _onNewSession) _onNewSession();
+export const login = (host?: string) =>
+  quiqFetch(
+    `${getSessionApiUrl(host)}/generate`,
+    {
+      credentials: 'include',
+      method: 'POST',
+    },
+    {
+      responseType: 'JSON',
+    },
+  ).then(res => {
+    if (_onNewSession) _onNewSession(res.tokenId);
   });
 
 export const validateSession = () => quiqFetch(getSessionApiUrl(), {credentials: 'include'});

--- a/src/stubbornFetch.js
+++ b/src/stubbornFetch.js
@@ -22,12 +22,13 @@ export const onInit = () => {
   initialized = true;
 };
 
-const bypassUrls = ['/session/web', '/agents-available'];
+const bypassUrls = ['/session/web', '/agents-available', '/chat'];
 
-let retryCount = 0;
-let timedOut = false;
-let timerId;
 export default (url: string, fetchRequest: RequestOptions) => {
+  let retryCount = 0;
+  let timedOut = false;
+  let timerId;
+
   const delayIfNeeded = () =>
     new Promise(resolve => {
       window.setTimeout(function() {
@@ -71,7 +72,7 @@ export default (url: string, fetchRequest: RequestOptions) => {
                 callbacks.onRetryableError();
               }
 
-              return login(null, true).then(validateSession).then(request);
+              return login().then(validateSession).then(request);
             }
 
             // Retry
@@ -128,7 +129,7 @@ export default (url: string, fetchRequest: RequestOptions) => {
               }
 
               retryCount++;
-              return login(null, true).then(validateSession).then(request);
+              return login().then(validateSession).then(request);
             }
 
             if (callbacks.onError) {

--- a/src/stubbornFetch.js
+++ b/src/stubbornFetch.js
@@ -71,7 +71,7 @@ export default (url: string, fetchRequest: RequestOptions) => {
                 callbacks.onRetryableError();
               }
 
-              return login().then(validateSession).then(request);
+              return login(null, true).then(validateSession).then(request);
             }
 
             // Retry
@@ -128,7 +128,7 @@ export default (url: string, fetchRequest: RequestOptions) => {
               }
 
               retryCount++;
-              return login().then(validateSession).then(request);
+              return login(null, true).then(validateSession).then(request);
             }
 
             if (callbacks.onError) {

--- a/src/types.js
+++ b/src/types.js
@@ -51,6 +51,7 @@ export type QuiqChatCallbacks = {
   onConnectionStatusChange?: (connected: boolean) => void,
   onRegistration?: () => void,
   onBurn?: () => void,
+  onNewSession?: () => void,
 };
 
 export type QuiqChatClientType = {


### PR DESCRIPTION
It is possible (though not common, unless a customer chooses to have tracking ID's last for a short period of time once this is an option) that a user's `trackingId` will change while they still have the chat window open. In this case we need to basically "reload" chat, so that they are connected to the correct web socket endpoint and have the new transcript displaying.

Basically, we keep track of the current trackingId and, if it changes, fire a callback back to FEFE, reconnect the websocket, and fetch the new transcript.