### PR TITLE
Temp code for QA

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "quiq-chat",
-  "version": "1.10.2",
+  "version": "1.10.3",
   "description": "Library to help with network requests to create a webchat client for Quiq Messaging",
   "main": "build/quiq-chat.js",
   "repository": "https://github.com/Quiq/quiq-chat",

--- a/src/QuiqChatClient.js
+++ b/src/QuiqChatClient.js
@@ -218,6 +218,10 @@ class QuiqChatClient {
     return this.userIsRegistered;
   };
 
+  DEPRECATED_AUTH_USER_DO_NOT_USE = () => {
+    API.DEPRECATED_AUTH_USER();
+  };
+
   /** Private Members * */
   _connectSocket = (wsInfo: {url: string}) => {
     connectSocket({

--- a/src/apiCalls.js
+++ b/src/apiCalls.js
@@ -6,6 +6,7 @@ import {
   getContactPoint,
   getSessionApiUrl,
   getGenerateUrl,
+  GET_DEPRECATED_AUTH_URL,
 } from './globals';
 import quiqFetch from './quiqFetch';
 import {setAccessToken, setTrackingId} from './storage';
@@ -89,6 +90,13 @@ export const login = (host?: string) =>
       }
     }
   });
+
+export const DEPRECATED_AUTH_USER = (host?: string) =>
+  quiqFetch(
+    GET_DEPRECATED_AUTH_URL(host),
+    {method: 'POST', credentials: 'include'},
+    {responseType: 'JSON'},
+  );
 
 export const validateSession = () => quiqFetch(getSessionApiUrl());
 

--- a/src/globals.js
+++ b/src/globals.js
@@ -47,4 +47,8 @@ export const getSessionApiUrl = (host?: string) => `${host || quiqChatSettings.H
 
 export const getTokenApiUrl = (host?: string) => `${host || quiqChatSettings.HOST}/api/v1/token`;
 
-export const getGenerateUrl = (host?: string) => `${getTokenApiUrl(host)}/generate`;
+export const getGenerateUrl = (host?: string) =>
+  `${getTokenApiUrl(host || quiqChatSettings.HOST)}/generate`;
+
+export const GET_DEPRECATED_AUTH_URL = (host?: string) =>
+  `${getSessionApiUrl(host || quiqChatSettings.HOST)}/generate`;


### PR DESCRIPTION
This code will be removed once we finish upgrading all chat clients to the new way of authing.  We need this to test the hand-over code and verify having both the old style and new style of auth work in conjunction.